### PR TITLE
updated system to `ars` from `osric`, and reported compatibility with…

### DIFF
--- a/module.json
+++ b/module.json
@@ -35,7 +35,7 @@
     ],
     "systems": [
       {
-        "id": "osric",
+        "id": "ars",
         "type": "system",
         "compatibility": {}
       }
@@ -43,6 +43,6 @@
   },
   "compatibility": {
     "minimum": "9.238",
-    "verified": "9"
+    "verified": "11"
   }
 }


### PR DESCRIPTION
… v.11.

With these changes, the plugin should "just work" with the most recent Advanced Roleplay System and Foundry 11.